### PR TITLE
Correctly handle empty arrays

### DIFF
--- a/src/io.jl
+++ b/src/io.jl
@@ -119,7 +119,7 @@ function decode_string(decoder::Decoder)
     String(decode_fixed(decoder, nb))
 end
 
-_decode_zigzag(n::Integer) = (n >>> 1) ⊻ -(n & 1)
+_decode_zigzag(n::T) where T <: Integer = (n >>> one(T)) ⊻ -(n & one(T))
 
 function _decode_varint(stream::IO, ::Type{T}) where T <: Integer
     max_bytes = sizeof(T) + ceil(Int, sizeof(T) / 8)


### PR DESCRIPTION
If the array was of size zero, previous code would output a spurious extra 0 byte.

Also fixes a type problem where decoded Int was returned as Int64. This is a problem for round-trip because the result could not be reserialized.